### PR TITLE
Python 3.4 compatibility

### DIFF
--- a/pako/config_loader.py
+++ b/pako/config_loader.py
@@ -56,10 +56,9 @@ def try_write_empty_config_stub():
 
         fd, path = tempfile.mkstemp()
         with open(fd, 'w') as temp:
-            json.dump({
-                **{i: {} for i in get_package_manager_names()},
-                '__order__': []
-            }, temp, indent=4)
+            base = {i: {} for i in get_package_manager_names()}
+            base['__order__']: []
+            json.dump(base, temp, indent=4)
         call(['sudo', 'mv', path, config_file])
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import setup
 
 setup(
     name='pako',
-    version='0.2.1',
+    version='0.2.2',
     packages=['pako'],
     install_requires=['appdirs'],
     url='https://github.com/MycroftAI/pako',


### PR DESCRIPTION
Python 3.4 doesn't support the unpacking of dicts into dicts (Introduced in python 3.5, see [PEP 448](https://www.python.org/dev/peps/pep-0448/))