### PR TITLE
added support for pacman, yum and zypper 

### DIFF
--- a/pako/package_manager_data.py
+++ b/pako/package_manager_data.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from pako.config_loader import recursive_merge, load_package_managers_overrides
 
 __package_managers = {
-    '__order__': ['eopkg', 'apt-get', 'rpm-ostree', 'dnf'],
+    '__order__': ['eopkg', 'apt-get', 'rpm-ostree', 'dnf', 'pacman', 'yum', 'zypper'],
     'eopkg': {
         'sudo': True,
         'update': 'ur',
@@ -39,7 +39,7 @@ __package_managers = {
     'apt-get': {
         'sudo': True,
         'update': 'update',
-        'install': 'install',
+        'install': 'install -y',
         'formats': {
             'exe': ['{}', '{}-utils'],
             'lib': ['lib{}', '{}'],
@@ -67,6 +67,39 @@ __package_managers = {
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
             'lib-dev': ['{}-devel', 'lib{}-devel'],
             'lib-debug': ['{}-debuginfo', 'lib{}-debuginfo'],
+        }
+    },
+    'pacman': {
+        'sudo': True,
+        'update': 'Syu --needed --noconfirm',
+        'install': 'Sy --needed --noconfirm',
+        'formats': {
+            'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
+            'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
+            'lib-dev': [''],
+            'lib-debug': ['{}-debug'],
+        }
+    },
+    'yum': {
+        'sudo': True,
+        'update': 'update -y',
+        'install': 'install -y',
+        'formats': {
+            'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
+            'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
+            'lib-dev': ['{}-devel'],
+            'lib-debug': ['{}-debug','{}-dbg'],
+        }
+    },
+    'zypper': {
+        'sudo': True,
+        'update': 'update -y',
+        'install': 'install -y',
+        'formats': {
+            'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
+            'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
+            'lib-dev': ['{}-devel'],
+            'lib-debug': ['{}-debug','{}-dbg'],
         }
     }
 }

--- a/pako/package_manager_data.py
+++ b/pako/package_manager_data.py
@@ -71,7 +71,7 @@ __package_managers = {
     },
     'pacman': {
         'sudo': True,
-        'update': 'Syu --needed --noconfirm',
+        'update': 'Syu --noconfirm',
         'install': 'Sy --needed --noconfirm',
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],

--- a/pako/package_manager_data.py
+++ b/pako/package_manager_data.py
@@ -28,7 +28,7 @@ __package_managers = {
     'eopkg': {
         'sudo': True,
         'update': 'ur',
-        'install': 'it -y',
+        'install': 'it',
         'formats': {
             'exe': ['{}', '{}-utils', '{}-bin'],
             'lib': ['{}', 'lib{}'],
@@ -39,7 +39,7 @@ __package_managers = {
     'apt-get': {
         'sudo': True,
         'update': 'update',
-        'install': 'install -y',
+        'install': 'install',
         'formats': {
             'exe': ['{}', '{}-utils'],
             'lib': ['lib{}', '{}'],
@@ -61,7 +61,7 @@ __package_managers = {
     'dnf': {
         'sudo': True,
         'update': 'check-update',
-        'install': 'install -y',
+        'install': 'install',
         'formats': {
             'exe': ['{}', '{}-utils'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
@@ -71,8 +71,8 @@ __package_managers = {
     },
     'pacman': {
         'sudo': True,
-        'update': 'Syu --noconfirm',
-        'install': 'Sy --needed --noconfirm',
+        'update': 'Syu',
+        'install': 'Sy',
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
@@ -82,8 +82,8 @@ __package_managers = {
     },
     'yum': {
         'sudo': True,
-        'update': 'update -y',
-        'install': 'install -y',
+        'update': 'update',
+        'install': 'install',
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
@@ -93,8 +93,8 @@ __package_managers = {
     },
     'zypper': {
         'sudo': True,
-        'update': 'update -y',
-        'install': 'install -y',
+        'update': 'update',
+        'install': 'install',
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],


### PR DESCRIPTION
#### Description
Added support for ArchLinux pacman, CentOS yum and OpenSUSE zypper to the package manager data
fixed missing argument on debians install (-y) (as it is featured in the readme.md)

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvement

#### CLA
👍 
