### PR TITLE
Add apk (Alpine Linux) support

### DIFF
--- a/pako/package_manager_data.py
+++ b/pako/package_manager_data.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from pako.config_loader import recursive_merge, load_package_managers_overrides
 
 __package_managers = {
-    '__order__': ['eopkg', 'apt-get', 'rpm-ostree', 'dnf', 'pacman', 'yum', 'zypper'],
+    '__order__': ['eopkg', 'apt-get', 'rpm-ostree', 'dnf', 'pacman', 'yum', 'zypper', 'apk'],
     'eopkg': {
         'sudo': True,
         'update': 'ur',
@@ -100,6 +100,17 @@ __package_managers = {
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
             'lib-dev': ['{}-devel'],
             'lib-debug': ['{}-debug','{}-dbg'],
+        }
+    },
+    'apk': {
+        'sudo': True,
+        'update': 'upgrade -a',
+        'install': 'add',
+        'formats': {
+            'exe': ['{}', '{}-utils', '{}-progs', '{}-tools'],
+            'lib': ['{}', 'lib{}', '{}-libs'],
+            'lib-dev': ['{}-dev'],
+            'lib-debug': ['{}-dbg'],
         }
     }
 }


### PR DESCRIPTION
#### Description
Add support for the APK package manager as used by Alpine Linux and postmarketOS.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Get an Alpine Linux system and test installing and upgrading packages.