### PR TITLE
Feature - add no-confirm flag

### DIFF
--- a/pako/__main__.py
+++ b/pako/__main__.py
@@ -24,8 +24,8 @@ from argparse import ArgumentParser
 from pako.pako_manager import PakoManager
 
 
-def install(args):
-    return PakoManager().install(args.packages)
+def install(*args, **kwargs):
+    return PakoManager().install(*args, **kwargs)
 
 
 def update(args):

--- a/pako/package_manager_data.py
+++ b/pako/package_manager_data.py
@@ -29,6 +29,9 @@ __package_managers = {
         'sudo': True,
         'update': 'ur',
         'install': 'it',
+        'flags': {
+            'no-confirm': '-y',
+        },
         'formats': {
             'exe': ['{}', '{}-utils', '{}-bin'],
             'lib': ['{}', 'lib{}'],
@@ -40,6 +43,9 @@ __package_managers = {
         'sudo': True,
         'update': 'update',
         'install': 'install',
+        'flags': {
+            'no-confirm': '-y',
+        },
         'formats': {
             'exe': ['{}', '{}-utils'],
             'lib': ['lib{}', '{}'],
@@ -73,6 +79,9 @@ __package_managers = {
         'sudo': True,
         'update': 'Syu',
         'install': 'Sy',
+        'flags': {
+            'no-confirm': '--noconfirm',
+        },
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
@@ -84,6 +93,9 @@ __package_managers = {
         'sudo': True,
         'update': 'update',
         'install': 'install',
+        'flags': {
+            'no-confirm': '-y',
+        },
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],
@@ -95,6 +107,9 @@ __package_managers = {
         'sudo': True,
         'update': 'update',
         'install': 'install',
+        'flags': {
+            'no-confirm': '-y',
+        },
         'formats': {
             'exe': ['{}', '{}-utils', '{}utils', '{}-bin'],
             'lib': ['{}', 'lib{}', '{}-lib', '{}-libs'],

--- a/pako/pako_manager.py
+++ b/pako/pako_manager.py
@@ -72,7 +72,7 @@ class PakoManager:
     def update(self):
         return self.call(self.config['update'].split()) == 0
 
-    def install_one(self, package: str, fmt: str = None) -> bool:
+    def install_one(self, package: str, fmt: str = None, flags: list = []) -> bool:
         if not fmt:
             package, fmt = PackageFormat.parse(package)
         if fmt not in PackageFormat.all:
@@ -87,19 +87,25 @@ class PakoManager:
                     if f not in possible_names:
                         possible_names.append(f)
 
+        install_cmd = self.config['install'].split()
+        if 'no-confirm' in flags:
+            install_cmd.append(self.config.get('flags').get('no-confirm'))
         for name in possible_names:
-            if self.call(self.config['install'].split() + [name.format(package)]) == 0:
+            if self.call(install_cmd + [name.format(package)]) == 0:
                 return True
         return False
 
-    def install(self, packages: list, overrides: dict = None) -> bool:
+    def install(self, packages: list, overrides: dict = None, flags: list = []) -> bool:
         if isinstance(packages, str):  # Easy mistake
             raise TypeError('Packages parameter must be a list')
         overrides = overrides or {}
         if self.name in overrides:
             packages = overrides[self.name]
-            return self.call(self.config['install'].split() + packages) == 0
+            install_cmd = self.config['install'].split()
+            if 'no-confirm' in flags:
+                install_cmd.append(self.config.get('flags').get('no-confirm'))
+            return self.call(install_cmd + packages) == 0
         for package in packages:
-            if not self.install_one(package):
+            if not self.install_one(package, flags=flags):
                 return False
         return True

--- a/pako/pako_manager.py
+++ b/pako/pako_manager.py
@@ -49,12 +49,18 @@ class PakoManager:
 
     @staticmethod
     def _find_package_manager(exes):
+        """Determine which package manager exists on a system."""
         for exe in exes:
             if which(exe):
                 return exe
         return None
 
     def call(self, args: list):
+        """Execute command for the available package manager.
+        
+        Arguments:
+            args (List): list of command line arguments use
+        """
         sudo_args = []
         if self.config['sudo']:
             sudo_args = ['sudo']
@@ -70,9 +76,19 @@ class PakoManager:
         return status
 
     def update(self):
+        """Update list of available packages."""
         return self.call(self.config['update'].split()) == 0
 
     def install_one(self, package: str, fmt: str = None, flags: list = []) -> bool:
+        """Install a single system package.
+
+        Arguments:
+            package (Str): Name of package to install
+            fmt (Str): Format of package name to use
+            flags (List[Str]): A list of command flags to use if available
+        Returns:
+            Bool: True if package was successfully installed
+        """
         if not fmt:
             package, fmt = PackageFormat.parse(package)
         if fmt not in PackageFormat.all:
@@ -96,6 +112,15 @@ class PakoManager:
         return False
 
     def install(self, packages: list, overrides: dict = None, flags: list = []) -> bool:
+        """Install system packages.
+
+        Arguments:
+            packages (List[Str]): A list of package names to install
+            overrides (Dict): A dictionary of package name formats to use
+            flags (List[Str]): A list of command flags to use if available
+        Returns:
+            Bool: True if all packages were successfully installed
+        """
         if isinstance(packages, str):  # Easy mistake
             raise TypeError('Packages parameter must be a list')
         overrides = overrides or {}


### PR DESCRIPTION
#### Description
This adds the ability to include a `-y` / `--noconfirm` flag on install commands. This ensures Skill dependencies can be installed without extra intervention by the user when performing Skill installs via voice.

More broadly it adds a flag dictionary that can be easily extended to include other command line flags in the future.

#### Type of PR
- [x] Feature implementation

#### Testing
Modify MSM to add the 'no-confirm' flag.
- If using MSM 0.9.0 - https://github.com/MycroftAI/mycroft-skills-manager/tree/feature/no-confirm-install
- If using MSM 0.8.8 - https://github.com/MycroftAI/mycroft-skills-manager/tree/feature/no-confirm-install-v0.8.8

If on a current Mycroft-core installation run:
```
mycroft-msm install pandora
```
Requires confirmation to install system packages.
```
mycroft-msm remove pandora
mycroft-pip install --no-cache --upgrade https://github.com/MycroftAI/pako/tarball/feature/no-confirm-flag
mycroft-pip install --no-cache --upgrade https://github.com/MycroftAI/mycroft-skills-manager/tarball/feature/no-confirm-install-v0.8.8
mycroft-msm install pandora
```
